### PR TITLE
Агент нахождения высоты мультимножества

### DIFF
--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/agent_of_finding_multiset_peak_value.scsi
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/agent_of_finding_multiset_peak_value.scsi
@@ -1,0 +1,127 @@
+agent_of_finding_multiset_peak_value
+=> nrel_main_idtf:
+	[агентная scp-программа нахождения высоты мультимножества] 
+	(* <- lang_ru;; *);
+	[agent scp-program of finding peak value of multiset] 
+	(* <- lang_en;; *);
+<- agent_scp_program;;
+
+scp_program -> agent_of_finding_multiset_peak_value (*
+    //множество параметров агентной scp-программы
+	-> rrel_params: .agent_of_finding_multiset_peak_value_params (*
+		-> rrel_1: rrel_in: _event;;
+		-> rrel_2: rrel_in: _input_arc;;
+		*);;
+
+    //множество операторов
+	-> rrel_operators: .agent_of_finding_multiset_peak_value_set (*
+        //первый исполняемый оператор
+		-> rrel_init: .agent_of_finding_multiset_peak_value1 (*
+			<- searchElStr3;;
+			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
+			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
+			=>nrel_goto: .agent_of_finding_multiset_peak_value2;;
+		*);;
+
+        //активация агента запросом
+		-> .agent_of_finding_multiset_peak_value2 (*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_finding_multiset_peak_value;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+			=>nrel_then: .agent_of_finding_multiset_peak_value3;;
+			=>nrel_else: .agent_of_finding_multiset_peak_value_return;;
+		*);;
+
+		-> .agent_of_finding_multiset_peak_value3 (*
+			<- printNl;;
+			-> rrel_1: rrel_fixed: rrel_scp_const: [агент нахождения высоты мультимножества];;
+			=> nrel_goto: .agent_of_finding_multiset_peak_value4;;
+   		*);;
+
+        //определение входных параметров от пользователя
+   		-> .agent_of_finding_multiset_peak_value4 (*
+			<- searchElStr3;;
+			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _multiset;;
+			=>nrel_then: .agent_of_finding_multiset_peak_value5;;
+			=>nrel_else: .agent_of_finding_multiset_peak_value_return;;
+		*);;
+
+	//поиск высоты мультимножества
+		-> .agent_of_finding_multiset_peak_value5 (*
+            <- call;;
+            -> rrel_1: rrel_fixed: rrel_scp_const: proc_of_finding_multiset_peak_value;;
+            -> rrel_2: ... (*
+                -> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+                -> rrel_2: rrel_assign: rrel_scp_var: _peak_value;;
+            *);;
+            -> rrel_3: rrel_assign: rrel_scp_var: _proc_descriptor;;
+            => nrel_goto: .agent_of_finding_multiset_peak_value6;;
+        *);;
+
+        ->.agent_of_finding_multiset_peak_value6 (*
+            <- waitReturn;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _proc_descriptor;;
+            => nrel_goto: .agent_of_finding_multiset_peak_value_operator_generate_and_add_to_answer;;
+        *);;
+
+		
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// создание связки отношения "пиковое значение мультимножества*" и добавление ее в ответ
+
+-> .agent_of_finding_multiset_peak_value_operator_generate_and_add_to_answer
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_add_multiset_peak_value_to_answer;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _peak_value;;
+					-> rrel_3: rrel_assign: rrel_scp_var: _answer;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .agent_of_finding_multiset_peak_value_operator_generate_and_add_to_answer_return;;
+		*);;
+
+		-> .agent_of_finding_multiset_peak_value_operator_generate_and_add_to_answer_return
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .agent_of_finding_multiset_peak_value_operator_bind_q_and_a;;
+		*);;
+		-> .agent_of_finding_multiset_peak_value_operator_bind_q_and_a
+		(*
+			<- genElStr5;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+			-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_const: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
+			
+			=> nrel_goto: .agent_of_finding_multiset_peak_value_operator_print_end;;
+		*);;
+	
+       -> .agent_of_finding_multiset_peak_value_operator_print_end
+		(*
+			<- printNl;;
+
+			-> rrel_1: rrel_scp_const: [Конец. Агент нахождения высоты мультимножества];;
+
+			=> nrel_goto: .agent_of_finding_multiset_peak_value_operator_return;;
+   		*);;
+
+	
+		-> .agent_of_finding_multiset_peak_value_operator_return (*
+			<- return;;
+		*);;
+	*);;
+*);;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_agent_of_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_agent_of_finding_multiset_peak_value.scs
@@ -1,0 +1,16 @@
+lib_component_agent_of_finding_multiset_peak_value
+=> nrel_main_idtf:
+	[Компонент библиотеки. sc-агент нахождения высоты мультимножества]
+	(* <- lang_ru;; *);
+	[Library component. sc-agent of finding multiset peak value]
+	(* <- lang_en;; *);
+
+<- platform_independent_reusable_component_OSTIS; 
+<- atomic_reusable_component_OSTIS; 
+<- reusable_scp_agent;
+
+=> nrel_attendant_component: 
+	lib_component_ui_menu_file_for_finding_multiset_peak_value; 
+
+-> rrel_key_sc_element: 
+	.platform_independent_realization_of_sc_agent_of_finding_multiset_peak_value;;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_proc_of_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_proc_of_finding_multiset_peak_value.scs
@@ -1,0 +1,14 @@
+lib_component_proc_of_finding_multiset_peak_value
+=> nrel_main_idtf:
+	[Компонент библиотеки. scp-программа нахождения высоты мультимножества]
+		(* <- lang_ru;; *);
+	[Library component. scp-program of finding multiset peak value]
+		(* <- lang_en;; *);
+
+<- platform_independent_reusable_component_OSTIS;
+<- reusable_scp_program;
+
+-> rrel_key_sc_element: 
+	proc_of_finding_multiset_peak_value;;
+
+lib_component_proc_of_finding_multiset_peak_valuee = [*^"file://proc_of_finding_multiset_peak_value.scs"*];;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_ui_menu_file_for_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/lib_component_ui_menu_file_for_finding_multiset_peak_value.scs
@@ -1,0 +1,12 @@
+lib_component_ui_menu_file_for_finding_multiset_peak_value
+=> nrel_main_idtf:
+	[Компонент библиотеки. Команда пользовательского интерфейса для нахождения высоты мультимножества]
+	(* <- lang_ru;; *);
+	[Library component. User interface command for finding multiset peak value]
+	(* <- lang_en;; *);
+
+<- platform_independent_reusable_component_OSTIS;
+<- atomic_reusable_component_OSTIS;
+<- reusable_knowledge_base_sc_model_component;;
+
+lib_component_ui_menu_file_for_finding_multiset_peak_value = [*^"file://ui_menu_file_for_finding_multiset_peak_value.scsi"*];; 

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_add_multiset_peak_value_to_answer.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_add_multiset_peak_value_to_answer.scs
@@ -84,21 +84,12 @@ scp_program -> proc_add_multiset_peak_value_to_answer
 			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
 			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value;;
 
-			//=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_check_value;;
             => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_form_answer;;
 		*);;
 
 ///////////////////////////////////////////////////////////////////////////////////
 // добавление сгенерированной конструкции в ответ
 
-
-		->.proc_add_multiset_peak_value_to_answer_operator_check_value (*
-            <- ifEq;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: _peak_value;;
-			-> rrel_2: rrel_fixed: rrel_scp_const: [0];;
-			=> nrel_then: .proc_add_multiset_peak_value_to_answer_operator_form_answer;;
-            => nrel_else: .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value;;
-        *);;
 
 		->.proc_add_multiset_peak_value_to_answer_operator_form_answer (*
             <- genElStr3;;
@@ -107,29 +98,6 @@ scp_program -> proc_add_multiset_peak_value_to_answer
 			-> rrel_3: rrel_fixed: rrel_scp_var: _multiset;;
 			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_relation;;
         *);;
-    -> .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value
-		(*
-			<- call;;
-
-			-> rrel_1: rrel_fixed: rrel_scp_const: proc_add_multiset_to_answer;;
-			-> rrel_2: rrel_fixed: rrel_scp_const: ...
-			(*
-					-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
-					-> rrel_2: rrel_assign: rrel_scp_var: _answer;;
-			*);;
-			-> rrel_3: rrel_assign: rrel_scp_var: _proc_descriptor;;
-
-			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value_return;;
-		*);;
-
-		-> .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value_return
-		(*
-			<- waitReturn;;
-
-			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_descriptor;;
-
-			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_relation;;
-		*);;
         
         -> .proc_add_multiset_peak_value_to_answer_operator_add_relation
         (*

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_add_multiset_peak_value_to_answer.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_add_multiset_peak_value_to_answer.scs
@@ -1,0 +1,257 @@
+scp_program -> proc_add_multiset_peak_value_to_answer
+(*
+    -> rrel_params: ...
+    (*
+        -> rrel_1: rrel_in: _multiset;;
+        -> rrel_2: rrel_in: _peak_value;;
+        -> rrel_3: rrel_out: _answer;;
+    *);;
+
+    -> rrel_operators: ...
+    (*
+    	
+        -> rrel_init: .proc_add_multiset_peak_value_to_answer_operator_print_start
+        (*
+            <- printNl;;
+
+            -> rrel_1: rrel_scp_const: [Начало. Процедура добавления высоты мультимножества в ответ];;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_generate_answer;;
+        *);;
+
+        -> .proc_add_multiset_peak_value_to_answer_operator_generate_answer
+        (*
+            <- genEl;;
+
+            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _answer;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_generate_peak_number;;
+        *);;
+
+	 
+		
+       /////////////формирование отношения
+	 -> .proc_add_multiset_peak_value_to_answer_operator_generate_peak_number
+        (*
+            <- genEl;;
+
+            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _peak_value_number;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_generate_relation;;
+        *);;
+       -> .proc_add_multiset_peak_value_to_answer_generate_relation
+		(*
+			<- genElStr5;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: rrel_const: _binary_arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value_number;;
+			-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_the_peak_value_of_the_multiset;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_generate_number_connection;;
+		*);;
+
+        -> .proc_add_multiset_peak_value_to_answer_generate_number_connection
+		(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: number;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value_number;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_generate_number_idtf;;
+		*);;
+
+        -> .proc_add_multiset_peak_value_to_answer_generate_number_idtf
+		(*
+			<- genElStr5;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _peak_value_number;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: rrel_const: _binary_arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value;;
+			-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_idtf;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_generate_lang_link;;
+		*);;
+
+        -> .proc_add_multiset_peak_value_to_answer_generate_lang_link
+		(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: lang_ru;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value;;
+
+			//=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_check_value;;
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_form_answer;;
+		*);;
+
+///////////////////////////////////////////////////////////////////////////////////
+// добавление сгенерированной конструкции в ответ
+
+
+		->.proc_add_multiset_peak_value_to_answer_operator_check_value (*
+            <- ifEq;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _peak_value;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: [0];;
+			=> nrel_then: .proc_add_multiset_peak_value_to_answer_operator_form_answer;;
+            => nrel_else: .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value;;
+        *);;
+
+		->.proc_add_multiset_peak_value_to_answer_operator_form_answer (*
+            <- genElStr3;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _multiset;;
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_relation;;
+        *);;
+    -> .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_add_multiset_to_answer;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+					-> rrel_2: rrel_assign: rrel_scp_var: _answer;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value_return;;
+		*);;
+
+		-> .proc_add_multiset_peak_value_to_answer_operator_add_multiset_peak_value_return
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_relation;;
+		*);;
+        
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_relation
+        (*
+            <- searchSetStr5;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: rrel_const: _binary_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _peak_value_number;;
+			-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_the_peak_value_of_the_multiset;;
+
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+
+            => nrel_then: .proc_add_multiset_peak_value_to_answer_operator_add_number;;
+        *);;
+
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_number
+		(*
+			<- searchSetStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: number;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value_number;;
+
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_add_number_idtf;;
+		*);;
+
+        -> .proc_add_multiset_peak_value_to_answer_add_number_idtf
+		(*
+			<- searchSetStr5;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _peak_value_number;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: rrel_const: _binary_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _peak_value_link;;
+			-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _idtf_arc;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_idtf;;
+
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_add_lang_link;;
+		*);;
+
+        -> .proc_add_multiset_peak_value_to_answer_add_lang_link
+		(*
+			<- searchSetStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: lang_ru;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _peak_value;;
+
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+
+			=> nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_nrel_peak_value;;
+		*);;
+        // добавление в ответ отношения "пиковое значение мультимножества*"
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_nrel_peak_value
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc_from_answer;;
+            -> rrel_3: rrel_fixed: rrel_scp_const: nrel_the_peak_value_of_the_multiset;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_lang_to_answer;;
+        *);;
+
+        // добавление в ответ класса языка
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_lang_to_answer
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc_from_answer;;
+            -> rrel_3: rrel_fixed: rrel_scp_const: lang_ru;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_number_to_answer;;
+        *);;
+
+        // добавление в ответ класса "число"
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_number_to_answer
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc_from_answer;;
+            -> rrel_3: rrel_fixed: rrel_scp_const: number;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_add_idtf_to_answer;;
+        *);;
+
+        // добавление в ответ отношения "идентификатор*"
+        -> .proc_add_multiset_peak_value_to_answer_operator_add_idtf_to_answer
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc_from_answer;;
+            -> rrel_3: rrel_fixed: rrel_scp_const: nrel_idtf;;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_print_end;;
+        *);;
+
+///////////////////////////////////////////////////////////////////////////////////
+
+        -> .proc_add_multiset_peak_value_to_answer_operator_print_end
+        (*
+            <- printNl;;
+
+            -> rrel_1: rrel_scp_const: [Конец. Процедура добавления пикового значения мультимножества в ответ];;
+
+            => nrel_goto: .proc_add_multiset_peak_value_to_answer_operator_return;;
+        *);;
+
+    	-> .proc_add_multiset_peak_value_to_answer_operator_return
+    	(*
+    		<- return;;
+    	*);;
+    *);;
+*);;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_of_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/proc_of_finding_multiset_peak_value.scs
@@ -1,0 +1,167 @@
+scp_program -> proc_of_finding_multiset_peak_value (*
+    -> rrel_params: ... (*
+        -> rrel_1: rrel_in: _multiset;;
+        -> rrel_2: rrel_out: _peak_value;;
+    *);;
+
+    -> rrel_operators: ... (*
+        -> rrel_init: .proc_of_finding_multiset_peak_value_start
+		(*
+			<- printNl;;
+
+			-> rrel_1: rrel_scp_const: [Начало. Процедура нахождения высоты мультимножества];;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_gen_result;;
+   		*);;
+
+	    -> .proc_of_finding_multiset_peak_value_gen_result
+		(*
+			<- genEl;;
+
+			-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _peak_value;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_assign_value;;
+		*);;
+
+        -> .proc_of_finding_multiset_peak_value_assign_value
+		(*
+			<- contAssign;;
+            -> rrel_1: rrel_assign: rrel_scp_var: _peak_value;;
+            -> rrel_2: rrel_fixed: rrel_scp_const: [0];;
+            => nrel_goto: .proc_of_finding_multiset_peak_value_gen_links_set;;
+		*);;
+        -> .proc_of_finding_multiset_peak_value_gen_links_set
+		(*
+			<- genEl;;
+
+			-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _links_set;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_copy_multiset;;
+		*);;
+        
+		-> .proc_of_finding_multiset_peak_value_copy_multiset
+		(*
+			<- searchSetStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _belonging_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _multiset_element;;
+
+			-> rrel_set_3: rrel_assign: rrel_scp_var: _multiset_element_set;;
+
+			=> nrel_then: .proc_of_finding_multiset_peak_value_operator1;;
+			=> nrel_else: .proc_of_finding_multiset_peak_value_operator_return;;
+		*);;
+        -> .proc_of_finding_multiset_peak_value_operator1
+		(*
+			<- searchElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _multiset_element_set;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _belonging_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _multiset_element;;
+
+			=> nrel_then: .proc_of_finding_multiset_peak_value_erase_multiset_element_arc;;
+			=> nrel_else: .proc_of_finding_multiset_peak_value_operator2;;
+		*);;
+
+		-> .proc_of_finding_multiset_peak_value_erase_multiset_element_arc
+		(*
+			<- eraseEl;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _belonging_arc;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_get_element_multiplicity;;
+		*);;
+
+		-> .proc_of_finding_multiset_peak_value_get_element_multiplicity
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_get_multiplicity_of_element;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _multiset;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _multiset_element;;
+
+					-> rrel_3: rrel_assign: rrel_scp_var: _element_multiplicity;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_get_element_multiplicity_return;;
+		*);;
+
+		-> .proc_of_finding_multiset_peak_value_get_element_multiplicity_return
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_descriptor;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_add_to_links_set;;
+		*);;
+
+        // добавление найденной кратности элемента во множество ссылок
+
+        -> .proc_of_finding_multiset_peak_value_add_to_links_set
+		(*
+			<- genElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _links_set;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _belonging_arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _element_multiplicity;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_operator1;;
+		*);;
+        
+        // цикл по множеству ссылок
+        -> .proc_of_finding_multiset_peak_value_operator2
+		(*
+			<- searchElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _links_set;;
+			-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _link_belonging_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _current_link;;
+
+			=> nrel_then: .proc_of_finding_multiset_peak_value_erase_multiset_link_belonging_arc;;
+			=> nrel_else: .proc_of_finding_multiset_peak_value_print_peak_value;;
+		*);;
+
+        -> .proc_of_finding_multiset_peak_value_erase_multiset_link_belonging_arc
+		(*
+			<- eraseEl;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _link_belonging_arc;;
+
+			=> nrel_goto: .proc_of_finding_multiset_peak_value_compare_current_link_and_peak;;
+		*);;
+
+        -> .proc_of_finding_multiset_peak_value_compare_current_link_and_peak
+		(*
+			<- ifGr;;
+            -> rrel_1: rrel_scp_var: _current_link;;
+            -> rrel_2: rrel_scp_var: _peak_value;;
+            => nrel_then: .proc_of_finding_multiset_peak_value_assign_current_link_to_peak;;
+            => nrel_else: .proc_of_finding_multiset_peak_value_operator2;;
+		*);;
+
+        -> .proc_of_finding_multiset_peak_value_assign_current_link_to_peak
+		(*
+			<- contAssign;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _peak_value;;
+            -> rrel_2: rrel_fixed: rrel_scp_var: _current_link;;
+            => nrel_goto: .proc_of_finding_multiset_peak_value_operator2;;
+		*);;
+
+
+        -> .proc_of_finding_multiset_peak_value_print_peak_value (*
+                <- printNl;;
+                -> rrel_1: rrel_fixed: rrel_scp_var:  _peak_value;;
+                => nrel_goto: .proc_of_finding_multiset_peak_value_operator_return;;
+        *);;
+
+         -> .proc_of_finding_multiset_peak_value_operator_return(*
+    	  <- return;;
+        *);;
+
+
+    *);;
+*);;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/sc_agent_of_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/sc_agent_of_finding_multiset_peak_value.scs
@@ -1,0 +1,52 @@
+sc_agent_of_finding_multiset_peak_value
+=> nrel_main_idtf:
+	[sc-агент нахождения высоты мультимножества] 
+	(* <- lang_ru;; *);
+	[sc-agent of finding multiset peak value] 
+	(* <- lang_en;; *);
+
+<- abstract_sc_agent;
+
+=> nrel_primary_initiation_condition: 
+		(sc_event_add_output_arc => question_initiated);
+
+=> nrel_initiation_condition_and_result: 
+		(..sc_agent_of_finding_multiset_peak_value => ..sc_agent_of_finding_multiset_peak_value_result);
+
+<= nrel_sc_agent_key_sc_elements:
+	{
+	question_initiated;
+	question;
+	question_finding_multiset_peak_value
+	};
+
+=> nrel_inclusion: 
+	.platform_independent_realization_of_sc_agent_of_finding_multiset_peak_value
+
+	(*
+	<- platform_independent_abstract_sc_agent;;
+	<= nrel_sc_agent_program: 
+		{
+		agent_of_finding_multiset_peak_value;
+		proc_of_finding_multiset_peak_value
+		};;
+	-> sc_agent_of_finding_multiset_peak_value_scp
+ (* <- active_sc_agent;; *);;
+	*);;
+
+..sc_agent_of_finding_multiset_peak_value
+= [*
+	question_finding_multiset_peak_value _-> .._question;;
+	question_initiated _-> .._question;;
+	question _-> .._question;;
+	.._question _-> .._parameter;;
+*];;
+
+..sc_agent_of_finding_multiset_peak_value_result
+= [*
+	question_finding_multiset_peak_value _-> .._question;;
+	question_finished _-> .._question;;
+	question _-> .._question;;
+	.._question _=> nrel_answer:: .._answer;;
+	.._question _-> .._parameter;;
+*];;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/sc_text_of_agent_of_finding_multiset_peak_value.scs
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/sc_text_of_agent_of_finding_multiset_peak_value.scs
@@ -1,0 +1,13 @@
+sc_text_of_agent_of_finding_multiset_peak_value
+-> rrel_key_sc_element:
+	agent_of_finding_multiset_peak_value;
+
+<- scp_program_sc_text;
+
+=> nrel_main_idtf: 
+	[sc-текст агентной scp-программы нахождения высоты мультимножества] 
+	(* <- lang_ru;; *);
+	[sc-text scp-agent based program finding the peak value of multiset] 
+	(* <- lang_en;; *);;
+
+sc_text_of_agent_of_finding_multiset_peak_value = [*^"file://agent_of_finding_multiset_peak_value.scsi"*];;

--- a/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/ui_menu_file_for_finding_multiset_peak_value.scsi
+++ b/set_theory_agents/agents_multiset_operations/agent_of_finding_multiset_peak_value/ui_menu_file_for_finding_multiset_peak_value.scsi
@@ -1,0 +1,19 @@
+ui_menu_file_for_finding_multiset_peak_value
+	<- 	ui_user_command_class_atom; 
+		ui_user_command_class_view_kb;
+	=> nrel_main_idtf: 
+		[Какова высота мультимножества?] (* <- lang_ru;; *);
+		[What is peak value of the multiset?] (* <- lang_en;; *);
+	=> ui_nrel_command_template:
+		[*
+		question_finding_multiset_peak_value _-> ._question_finding_multiset_peak_value_instance
+			(*
+				_-> ui_arg_1;;
+			*);;
+		._question_finding_multiset_peak_value_instance _<- question;;
+		*];
+	=> ui_nrel_command_lang_template: 
+		[Запрос нахождения высоты мультимножества: $ui_arg_1] 
+		(* <- lang_ru;; *);
+		[What is peak value of $ui_arg_1] 
+		(* <- lang_en;; *);;

--- a/set_theory_knowledge_base/subject_domain_of_set_theory/section_subject_domain_of_sets/section_sets_relations/section_relations_on_multisets/section_relations_on_multisets.scsi
+++ b/set_theory_knowledge_base/subject_domain_of_set_theory/section_subject_domain_of_sets/section_sets_relations/section_relations_on_multisets/section_relations_on_multisets.scsi
@@ -63,6 +63,11 @@ nrel_the_peak_value_of_the_multiset
 		...
 		(*
 		<- sc_definition;;
+
+        => nrel_main_idtf:
+	    [Опр. (пиковое значение мультимножества*)]
+	    (* <- lang_ru;; *);;
+
 		<= nrel_sc_text_translation:
 			...
 			(*
@@ -75,11 +80,7 @@ nrel_the_peak_value_of_the_multiset
 			->element_of_set;;
 			->nrel_the_multiplicity_of_the_element;;
 		*);;
-		*);
-
-        => nrel_main_idtf:
-	    [Опр. (кратность мультимножества*)]
-	    (* <- lang_ru;; *);;
+		*);;
 
 nrel_the_peak_value_of_the_multiset
 <- rrel_key_sc_element:

--- a/set_theory_ui/menu/ui_menu_na_multisets.scs
+++ b/set_theory_ui/menu/ui_menu_na_multisets.scs
@@ -9,5 +9,6 @@ ui_menu_na_multisets
     ui_menu_file_for_finding_multisets_sum;
     ui_menu_file_for_finding_multisets_product;
     ui_menu_file_for_finding_multisets_union;
+    ui_menu_file_for_finding_multiset_peak_value;
 	ui_menu_file_for_printing_multiset
 };;


### PR DESCRIPTION
Использует процедуру proc_get_multiplicity_of_element.
На вход агента подается одно мультимножество, в ответ генерируется конструкция, содержащая высоту данного мультимножества - максимальное значение кратности вхождения его элементов. Если множество пусто, то в ответе будет 0.