### PR TITLE
Fixed operations on relations

### DIFF
--- a/set_theory_agents/agents_operations_on_relations/agent_of_finding_converse_relation/proc_of_finding_converse_relation.scs
+++ b/set_theory_agents/agents_operations_on_relations/agent_of_finding_converse_relation/proc_of_finding_converse_relation.scs
@@ -1,32 +1,32 @@
 scp_program -> proc_of_finding_converse_relation 
 	(*	
-	-> rrel_params: .proc_of_finding_converse_relation_params 
+	-> rrel_params: ..proc_of_finding_converse_relation_params 
 		(*
 		-> rrel_1: rrel_in: _A;;
 		-> rrel_2: rrel_out: _answer;;
 		*);;
 
-	-> rrel_operators: .proc_of_finding_converse_relation_operator_set 
+	-> rrel_operators: ..proc_of_finding_converse_relation_operator_set 
 		(*
-		-> rrel_init: .proc_of_finding_converse_relation_operator0 (*
+		    -> rrel_init: ..proc_of_finding_converse_relation_operator0 (*
 				<- printNl;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: [агент нахождения обратного отношения];;
-				=> nrel_goto: .proc_of_finding_converse_relation_operator01;;
+				=> nrel_goto: ..proc_of_finding_converse_relation_operator01;;
 	   		*);;
 
-	    	-> .proc_of_finding_converse_relation_operator01 (*
+	    	-> ..proc_of_finding_converse_relation_operator01 (*
 				<- genEl;;
 				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _newrel;;
-				=> nrel_goto: .proc_of_finding_converse_relation_operator1;;
+				=> nrel_goto: ..proc_of_finding_converse_relation_operator1;;
 			*);;
 
-	    	-> .proc_of_finding_converse_relation_operator1 (*
+	    	-> ..proc_of_finding_converse_relation_operator1 (*
 				<- genEl;;
 				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
-				=> nrel_goto: .proc_of_finding_converse_relation_operator2;;
+				=> nrel_goto: ..proc_of_finding_converse_relation_operator2;;
 			*);;
 
-			-> .proc_of_finding_converse_relation_operator2 (*
+			-> ..proc_of_finding_converse_relation_operator2 (*
 				<- genElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _A;;
 				-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc1;;
@@ -34,58 +34,55 @@ scp_program -> proc_of_finding_converse_relation
 				-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 				-> rrel_5: rrel_fixed: rrel_scp_const: nrel_converse_relation;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator3;;
+			    => nrel_goto: ..proc_of_finding_converse_relation_operator3;;
 			*);;
 
-			-> .proc_of_finding_converse_relation_operator3 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_converse_relation_operator3 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator4;;
+			    => nrel_goto: ..proc_of_finding_converse_relation_operator4;;
 			*);;
 
-			-> .proc_of_finding_converse_relation_operator4 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_converse_relation_operator4 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _newrel;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator5;;
+			    => nrel_goto: ..proc_of_finding_converse_relation_operator5;;
 			*);;
 
-			->.proc_of_finding_converse_relation_operator5 (*
-			 <- genElStr3;;
+			->..proc_of_finding_converse_relation_operator5 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: nrel_converse_relation;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator6;;
+			    => nrel_goto: ..proc_of_finding_converse_relation_operator6;;
 			*);; 
 
-			-> .proc_of_finding_converse_relation_operator6 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_converse_relation_operator6 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _arc1;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator7;;
+			    => nrel_goto: ..proc_of_finding_converse_relation_operator7;;
 			*);;
 
-			->.proc_of_finding_converse_relation_operator7 (*
-			 <- genElStr3;;
+			->..proc_of_finding_converse_relation_operator7 (*
+				<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _arc2;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator10;;
-			*);; 
+			  	=> nrel_goto: ..proc_of_finding_converse_relation_operator10;;
+			*);;
 
-//gen converse rel
-
-
-			->.proc_of_finding_converse_relation_operator10 (*
+			->..proc_of_finding_converse_relation_operator10 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -96,11 +93,11 @@ scp_program -> proc_of_finding_converse_relation
 		  		-> rrel_set_1: rrel_fixed: rrel_scp_var: rrel_node: rrel_const: _answer;;		  	
 		  		-> rrel_set_3: rrel_fixed: rrel_scp_var: rrel_node: rrel_const: _answer;;
 
-	             => nrel_then: .proc_of_finding_converse_relation_operator11;;
-	             => nrel_else: .proc_of_finding_converse_relation_operator_return;;
+	            => nrel_then: ..proc_of_finding_converse_relation_operator11;;
+	            => nrel_else: ..proc_of_finding_converse_relation_operator_return;;
 			*);; 
 			
-			-> .proc_of_finding_converse_relation_operator11 (*
+			-> ..proc_of_finding_converse_relation_operator11 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -111,43 +108,44 @@ scp_program -> proc_of_finding_converse_relation
 		  		-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_goto: .proc_of_finding_converse_relation_operator12;;
+	             => nrel_goto: ..proc_of_finding_converse_relation_operator12;;
 			*);;
 			
-			-> .proc_of_finding_converse_relation_operator12 (*
+			-> ..proc_of_finding_converse_relation_operator12 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element1;;
 
-	            => nrel_then: .proc_of_finding_converse_relation_operator13;;
-	            => nrel_else: .proc_of_finding_converse_relation_operator_return;;
+	            => nrel_then: ..proc_of_finding_converse_relation_operator13;;
+	            => nrel_else: ..proc_of_finding_converse_relation_operator_return;;
 			*);;
 
-        -> .proc_of_finding_converse_relation_operator13(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_converse_relation_operator13(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-					=> nrel_goto: .proc_of_finding_converse_relation_operator14;;
-					*);;	
+				=> nrel_goto: ..proc_of_finding_converse_relation_operator14;;
+			*);;	
 
-        -> .proc_of_finding_converse_relation_operator14 (*
+        	-> ..proc_of_finding_converse_relation_operator14 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedB;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delB;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
 
-	            => nrel_then: .proc_of_finding_converse_relation_operator15;;
-	            => nrel_else: .proc_of_finding_converse_relation_operator16;;
+	            => nrel_then: ..proc_of_finding_converse_relation_operator15;;
+	            => nrel_else: ..proc_of_finding_converse_relation_operator16;;
 			*);;
 
-        -> .proc_of_finding_converse_relation_operator15(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delB;;
+        	-> ..proc_of_finding_converse_relation_operator15(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delB;;
 
-			=> nrel_goto: .proc_of_finding_converse_relation_operator17;;
-		*);;			
-        ->.proc_of_finding_converse_relation_operator16 (*
+				=> nrel_goto: ..proc_of_finding_converse_relation_operator17;;
+			*);;	
+
+        	->..proc_of_finding_converse_relation_operator16 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -157,11 +155,11 @@ scp_program -> proc_of_finding_converse_relation
 		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_converse_relation_operator12;;
-	             => nrel_else: .proc_of_finding_converse_relation_operator_return;;
+	             => nrel_then: ..proc_of_finding_converse_relation_operator12;;
+	             => nrel_else: ..proc_of_finding_converse_relation_operator_return;;
 			*);; 
 
-			->.proc_of_finding_converse_relation_operator17 (*
+			->..proc_of_finding_converse_relation_operator17 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -169,11 +167,11 @@ scp_program -> proc_of_finding_converse_relation
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_converse_relation_operator018;;
-	            => nrel_else: .proc_of_finding_converse_relation_operator14;;
+	            => nrel_then: ..proc_of_finding_converse_relation_operator018;;
+	            => nrel_else: ..proc_of_finding_converse_relation_operator14;;
 			*);; 
 
-			->.proc_of_finding_converse_relation_operator018 (*
+			->..proc_of_finding_converse_relation_operator018 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -181,11 +179,11 @@ scp_program -> proc_of_finding_converse_relation
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _newrel;;
 
-	            => nrel_then: .proc_of_finding_converse_relation_operator14;;
-	            => nrel_else: .proc_of_finding_converse_relation_operator18;;
+	            => nrel_then: ..proc_of_finding_converse_relation_operator14;;
+	            => nrel_else: ..proc_of_finding_converse_relation_operator18;;
 			*);; 
 
-			->.proc_of_finding_converse_relation_operator18 (*
+			->..proc_of_finding_converse_relation_operator18 (*
 				<- genElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc1;;
@@ -193,29 +191,29 @@ scp_program -> proc_of_finding_converse_relation
 				-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _newrel;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator19;;
+			  	=> nrel_goto: ..proc_of_finding_converse_relation_operator19;;
 			*);; 
 
-			-> .proc_of_finding_converse_relation_operator19 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_converse_relation_operator19 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _arc1;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator20;;
+			 	=> nrel_goto: ..proc_of_finding_converse_relation_operator20;;
 			*);;
 
-			-> .proc_of_finding_converse_relation_operator20 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_converse_relation_operator20 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _arc2;;
 
-			  => nrel_goto: .proc_of_finding_converse_relation_operator14;;
+			  	=> nrel_goto: ..proc_of_finding_converse_relation_operator14;;
 			*);;
 
-			-> .proc_of_finding_converse_relation_operator_return 
-				(*
+			-> ..proc_of_finding_converse_relation_operator_return 
+			(*
 				<- return;;
 			*);;
 		*);;

--- a/set_theory_agents/agents_operations_on_relations/agent_of_finding_relations_propertes/proc_of_finding_relations_propertes.scs
+++ b/set_theory_agents/agents_operations_on_relations/agent_of_finding_relations_propertes/proc_of_finding_relations_propertes.scs
@@ -1,464 +1,484 @@
 scp_program -> proc_of_finding_relations_propertes 
 	(*	
-	-> rrel_params: .proc_of_finding_relations_propertes_params 
+	-> rrel_params: ..proc_of_finding_relations_propertes_params 
 		(*
 		-> rrel_1: rrel_in: _A;;
 		-> rrel_2: rrel_out: _answer;;
 		*);;
 
-	-> rrel_operators: .proc_of_finding_relations_propertes_operator_set 
+	-> rrel_operators: ..proc_of_finding_relations_propertes_operator_set 
 		(*
-		-> rrel_init: .proc_of_finding_relations_propertes_operator0 (*
+			-> rrel_init: ..proc_of_finding_relations_propertes_operator0 (*
 				<- printNl;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: [агент нахождения свойств отношения];;
-				=> nrel_goto: .proc_of_finding_relations_propertes_operator1;;
+				=> nrel_goto: ..proc_of_finding_relations_propertes_operator1;;
 	   		*);;
 
-	    	-> .proc_of_finding_relations_propertes_operator1 (*
+	    	-> ..proc_of_finding_relations_propertes_operator1 (*
 				<- genEl;;
 				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _result;;
-				=> nrel_goto: .proc_of_finding_relations_propertes_operator2;;
+				=> nrel_goto: ..proc_of_finding_relations_propertes_operator2;;
 			*);;
 
-	   		->.proc_of_finding_relations_propertes_operator2 (*
+	   		->..proc_of_finding_relations_propertes_operator2 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator3;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator4;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator3;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator4;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator3 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator3 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator4;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator4;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator4 (*
+			->..proc_of_finding_relations_propertes_operator4 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: class_of_connectives_with_diffetent_capacities;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator5;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator6;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator5;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator6;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator5 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator5 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: class_of_connectives_with_diffetent_capacities;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator6;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator6;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator6 (*
+			->..proc_of_finding_relations_propertes_operator6 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: class_of_non_binary_connectives_same_capacities;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator7;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator8;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator7;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator8;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator7 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator7 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: class_of_non_binary_connectives_same_capacities;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator8;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator8;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator8 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator9;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator10;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator9 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: binary_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator10;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator10 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: non_oriented_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator11;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator12;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator11 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: non_oriented_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator12;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator12 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: oriented_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator13;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator14;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator13 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: oriented_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator14;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator14 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator15;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator16;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator15 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator16;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator16 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: equivalence_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator17;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator18;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator17 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: equivalence_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator18;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator18 (*
+			->..proc_of_finding_relations_propertes_operator8 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: unary_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator19;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator20;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator9;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator10;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator19 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator9 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: unary_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator20;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator20 (*
+			->..proc_of_finding_relations_propertes_operator10 (*
 				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: strict_order_relation;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator21;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator22;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator11;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator12;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator21 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator11 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: strict_order_relation;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: binary_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator22;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator16;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator22 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: role_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator23;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator24;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator23 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: role_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator24;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator24 (*
+			->..proc_of_finding_relations_propertes_operator12 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: ternary_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator25;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator26;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator13;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator14;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator25 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator13 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: ternary_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator26;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator26 (*
+			->..proc_of_finding_relations_propertes_operator14 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: quasybinary_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator27;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator28;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator15;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator16;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator27 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator15 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: quasybinary_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator28;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator28 (*
+			->..proc_of_finding_relations_propertes_operator16 (*
 				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: asymmetric_relation;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: oriented_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator29;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator30;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator17;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator18;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator29 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator17 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: asymmetric_relation;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: oriented_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator30;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator20;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator30 (*
+			->..proc_of_finding_relations_propertes_operator18 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: non_oriented_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator19;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator20;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator19 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: non_oriented_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator20;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator20 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: symmetric_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator31;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator32;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator21;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator22;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator31 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator21 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: symmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator32;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator26;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator32 (*
+			->..proc_of_finding_relations_propertes_operator22 (*
 				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: transitive_relation;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: asymmetric_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator33;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator34;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator23;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator24;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator33(*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator23 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: transitive_relation;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: asymmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator34;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator26;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator34 (*
+			->..proc_of_finding_relations_propertes_operator24 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator25;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator26;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator25 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator26;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator26 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: reflexive_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator35;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator36;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator27;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator28;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator35 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator27 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: reflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator36;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator32;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator36 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: order_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator37;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator38;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator37 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: order_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator38;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator38 (*
-				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
-				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
-
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator39;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator40;;
-			*);; 
-
-			-> .proc_of_finding_relations_propertes_operator39 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
-
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator40;;
-			*);;
-
-			->.proc_of_finding_relations_propertes_operator40 (*
+			->..proc_of_finding_relations_propertes_operator28 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: areflexive_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator41;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator42;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator29;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator30;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator41 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator29 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: areflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator42;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator32;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator42 (*
+			->..proc_of_finding_relations_propertes_operator30 (*
 				<- searchElStr3;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: non_strict_order_relation;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator43;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator44;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator31;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator32;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator43 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator31 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: non_strict_order_relation;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: antireflexive_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator44;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator32;;
 			*);;
 
-			->.proc_of_finding_relations_propertes_operator44 (*
+			->..proc_of_finding_relations_propertes_operator32 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: equivalence_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator33;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator34;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator33(*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: equivalence_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator34;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator34 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: related_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_propertes_operator45;;
-	                 	=> nrel_else: .proc_of_finding_relations_propertes_operator46;;
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator35;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator36;;
 			*);; 
 
-			-> .proc_of_finding_relations_propertes_operator45 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_propertes_operator35 (*
+			    <- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: related_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_propertes_operator46;;
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator36;;
 			*);;
 
-			-> .proc_of_finding_relations_propertes_operator46 (*
+			->..proc_of_finding_relations_propertes_operator36 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: order_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator37;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator38;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator37 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: order_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator38;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator38 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: strict_order_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator39;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator40;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator39 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: strict_order_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator42;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator40 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: non_strict_order_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator41;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator42;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator41 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: non_strict_order_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator42;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator42 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: transitive_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator43;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator44;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator43 (*
+			 <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: transitive_relation;;
+
+			    => nrel_goto: ..proc_of_finding_relations_propertes_operator46;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator44 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: antitransitive_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator45;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator46;;
+			*);; 
+
+			-> ..proc_of_finding_relations_propertes_operator45 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: antitransitive_relation;;
+
+			  	=> nrel_goto: ..proc_of_finding_relations_propertes_operator46;;
+			*);;
+
+			->..proc_of_finding_relations_propertes_operator46 (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: role_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_propertes_operator47;;
+	            => nrel_else: ..proc_of_finding_relations_propertes_operator48;;
+			*);;
+
+			-> ..proc_of_finding_relations_propertes_operator47 (*
+			    <- genElStr3;;
+			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_const: role_relation;;
+
+			  	=> nrel_goto: ..proc_of_finding_relations_propertes_operator48;;
+			*);;
+
+			-> ..proc_of_finding_relations_propertes_operator48 (*
 				<- call;; 
 				-> rrel_1: rrel_fixed: rrel_scp_const:  proc_add_three_elements;;
 				->rrel_2:rrel_fixed:rrel_scp_const: 
-				.proc_of_finding_relations_propertes_operator46_params (*
+				..proc_of_finding_relations_propertes_operator46_params (*
 					-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 					-> rrel_2: rrel_fixed: rrel_scp_var: _A;;
 					-> rrel_3: rrel_assign: rrel_scp_var: _answer;;
 				*);;
 				-> rrel_3: rrel_assign: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_propertes_operator47;;
+
+				=>nrel_goto: ..proc_of_finding_relations_propertes_operator49;;
 			*);;
 
-			-> .proc_of_finding_relations_propertes_operator47 (*
+			-> ..proc_of_finding_relations_propertes_operator49 (*
 				<- waitReturn;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_propertes_operator_return;;
+
+				=>nrel_goto: ..proc_of_finding_relations_propertes_operator_return;;
 			*);;
 
-			-> .proc_of_finding_relations_propertes_operator_return 
-				(*
+			-> ..proc_of_finding_relations_propertes_operator_return (*
 				<- return;;
 			*);;
 		*);;

--- a/set_theory_agents/agents_operations_on_relations/agent_of_finding_relations_symmetric_propertes/proc_of_finding_relations_symmetric_propertes.scs
+++ b/set_theory_agents/agents_operations_on_relations/agent_of_finding_relations_symmetric_propertes/proc_of_finding_relations_symmetric_propertes.scs
@@ -1,83 +1,100 @@
 scp_program -> proc_of_finding_relations_symmetric_propertes 
 	(*	
-	-> rrel_params: .proc_of_finding_relations_symmetric_propertes_params 
+	-> rrel_params: ..proc_of_finding_relations_symmetric_propertes_params 
 		(*
 		-> rrel_1: rrel_in: _A;;
 		-> rrel_2: rrel_out: _answer;;
 		*);;
 
-	-> rrel_operators: .proc_of_finding_relations_symmetric_propertes_operator_set 
+	-> rrel_operators: ..proc_of_finding_relations_symmetric_propertes_operator_set 
 		(*
-		-> rrel_init: .proc_of_finding_relations_symmetric_propertes_operator0 (*
+			-> rrel_init: ..proc_of_finding_relations_symmetric_propertes_operator0 (*
 				<- printNl;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: [агент нахождения симметричных свойств отношения];;
-				=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator1;;
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator1;;
 	   		*);;
 
-	    	-> .proc_of_finding_relations_symmetric_propertes_operator1 (*
+	    	-> ..proc_of_finding_relations_symmetric_propertes_operator1 (*
 				<- genEl;;
 				-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _result;;
-				=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator2;;
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator_check_binary;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator2 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator_check_binary (*
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: binary_relation;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
+
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator2;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator_check_binary_error;;
+			*);; 
+
+			-> ..proc_of_finding_relations_symmetric_propertes_operator_check_binary_error (*
+			 	<- printNl;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: [Данный элемент не является бинарным отношением.];;
+
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator_return;;
+			*);;
+
+			-> ..proc_of_finding_relations_symmetric_propertes_operator2 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: symmetric_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_symmetric_propertes_operator5;;
-	                 	=> nrel_else: .proc_of_finding_relations_symmetric_propertes_operator6;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator5;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator6;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator5 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator5 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: symmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator6;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator6 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator6 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_symmetric_propertes_operator7;;
-	                 	=> nrel_else: .proc_of_finding_relations_symmetric_propertes_operator8;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator7;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator8;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator7 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator7 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator46;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator8 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator8 (*
 				<- searchElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: asymmetric_relation;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arcA;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_symmetric_propertes_operator9;;
-	                 	=> nrel_else: .proc_of_finding_relations_symmetric_propertes_operator010;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator9;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator010;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator9 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator9 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: asymmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator46;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator010 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator010 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
 				-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc1;;
@@ -85,29 +102,18 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	                 	=> nrel_then: .proc_of_finding_relations_symmetric_propertes_operator10;;
-	                 	=> nrel_else: .proc_of_finding_relations_symmetric_propertes_operator0000000;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0000;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator0000000;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator0000000 (*
-			 <- genElStr3;;
-			 	-> rrel_1: rrel_assign: rrel_scp_var: _answer;;
-				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-				-> rrel_3: rrel_fixed: rrel_scp_const: [Данный элемент не является отношением.];;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0000000 (*
+			 	<- printNl;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: [Данный элемент не является бинарным отношением.];;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator_return;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator_return;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator10 (*
-				<- printNl;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: [symmetric];;
-				=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator0000;;
-	   		*);;
-
-//symmetric
-
-
-			->.proc_of_finding_relations_symmetric_propertes_operator0000 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator0000 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -118,44 +124,45 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  		-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	             => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0001;;
+	             => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 			
-			-> .proc_of_finding_relations_symmetric_propertes_operator0001 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0001 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element1;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0002;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator0008;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0002;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator0008;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator0002(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator0002(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-					=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator0003;;
-					*);;	
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator0003;;
+			*);;	
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator0003 (*
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator0003 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedB;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0004;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator0005;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0004;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator0005;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator0004(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator0004(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-			=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator0006;;
-		*);;			
-        ->.proc_of_finding_relations_symmetric_propertes_operator0005 (*
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator0006;;
+			*);;
+
+        	->..proc_of_finding_relations_symmetric_propertes_operator0005 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -165,11 +172,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	             => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0001;;
+	             => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator0006 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator0006 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -177,11 +184,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0007;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator0003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0007;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator0003;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator0007 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator0007 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -189,39 +196,29 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator0003;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator100;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator0003;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator00000;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator0008 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0008 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: symmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator0009;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator0009;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator0009 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0009 (*
+			 	<- genElStr3;;
 				-> rrel_1: rrel_fixed: rrel_scp_const: symmetric_relation;;			 	
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator100;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator100 (*
-				<- printNl;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: [antisymmetric];;
-				=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator00000;;
-	   		*);;
-
-
-//antisymmetric
-
-
-			->.proc_of_finding_relations_symmetric_propertes_operator00000 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator00000 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -232,44 +229,45 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  		-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	             => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00001;;
+	             => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 			
-			-> .proc_of_finding_relations_symmetric_propertes_operator00001 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator00001 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element1;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00002;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000011;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00002;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000011;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator00002(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator00002(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-					=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator00003;;
-					*);;	
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator00003;;
+			*);;	
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator00003 (*
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator00003 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedB;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00004;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator00005;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00004;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator00005;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator00004(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator00004(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-			=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator00006;;
-		*);;			
-        ->.proc_of_finding_relations_symmetric_propertes_operator00005 (*
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator00006;;
+			*);;
+
+        	->..proc_of_finding_relations_symmetric_propertes_operator00005 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -279,11 +277,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	             => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00001;;
+	             => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator00006 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator00006 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -291,11 +289,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00007;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator00003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00007;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator00003;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator00007 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator00007 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -303,49 +301,39 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000010;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator00003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000010;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator00003;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator000010 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000010 (*
 				<- ifCoin;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_fixed: rrel_scp_var: _element1;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator00003;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator00003;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000000;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator000011 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator000011 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: antisymmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator000012;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator000012;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator000012 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator000012 (*
+			 	<- genElStr3;;
 
 				-> rrel_1: rrel_fixed: rrel_scp_const: antisymmetric_relation;;			 	
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator46;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			->.proc_of_finding_relations_symmetric_propertes_operator1000 (*
-				<- printNl;;
-				-> rrel_1: rrel_fixed: rrel_scp_const: [asymmetric];;
-				=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator000000;;
-	   		*);;
-
-
-//asymmetric
-
-
-			->.proc_of_finding_relations_symmetric_propertes_operator000000 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000000 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -356,44 +344,45 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  		-> rrel_set_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedA;;		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000001;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 			
-			-> .proc_of_finding_relations_symmetric_propertes_operator000001 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator000001 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedA;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element1;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000002;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator0000010;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000002;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator0000010;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator000002(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator000002(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-					=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator000003;;
-					*);;	
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator000003;;
+			*);;	
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator000003 (*
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator000003 (*
 				<- searchElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _not_checkedB;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc_for_delA;;
 				-> rrel_3: rrel_assign: rrel_scp_var: _element2;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000004;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000005;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000004;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000005;;
 			*);;
 
-        -> .proc_of_finding_relations_symmetric_propertes_operator000004(*
-			<- eraseEl;;
-			-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
+        	-> ..proc_of_finding_relations_symmetric_propertes_operator000004(*
+				<- eraseEl;;
+				-> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _arc_for_delA;;
 
-			=> nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator000006;;
-		*);;			
-        ->.proc_of_finding_relations_symmetric_propertes_operator000005 (*
+				=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator000006;;
+			*);;	
+
+        	->..proc_of_finding_relations_symmetric_propertes_operator000005 (*
 				<- searchSetStr5;;
 				-> rrel_1: rrel_assign: rrel_scp_var: _el1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arc;;
@@ -403,11 +392,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 		  	
 		  		-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _not_checkedB;;
 
-	             => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000001;;
-	             => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator46;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000001;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator000006 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000006 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -415,11 +404,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000007;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000008;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000007;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000008;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator000007 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000007 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -427,11 +416,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator46;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator46;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000003;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator000008 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000008 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element2;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -439,11 +428,11 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator000009;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator000009;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000003;;
 			*);; 
 
-			->.proc_of_finding_relations_symmetric_propertes_operator000009 (*
+			->..proc_of_finding_relations_symmetric_propertes_operator000009 (*
 				<- searchElStr5;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _element1;;
 				-> rrel_2: rrel_assign: rrel_scp_var: _arcA;;
@@ -451,50 +440,50 @@ scp_program -> proc_of_finding_relations_symmetric_propertes
 				-> rrel_4: rrel_assign: rrel_scp_var: _arcA;;
 				-> rrel_5: rrel_fixed: rrel_scp_var: _A;;
 
-	            => nrel_then: .proc_of_finding_relations_symmetric_propertes_operator46;;
-	            => nrel_else: .proc_of_finding_relations_symmetric_propertes_operator000003;;
+	            => nrel_then: ..proc_of_finding_relations_symmetric_propertes_operator46;;
+	            => nrel_else: ..proc_of_finding_relations_symmetric_propertes_operator000003;;
 			*);; 
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator0000010 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0000010 (*
+			 	<- genElStr3;;
 			 	-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_const: asymmetric_relation;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator0000011;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator0000011;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator0000011 (*
-			 <- genElStr3;;
+			-> ..proc_of_finding_relations_symmetric_propertes_operator0000011 (*
+			 	<- genElStr3;;
 			 	
 				-> rrel_1: rrel_fixed: rrel_scp_const: asymmetric_relation;;			 	
 				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
 				-> rrel_3: rrel_fixed: rrel_scp_var: _A;;
 
-			  => nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator46;;
+			  	=> nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator46;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator46 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator46 (*
 				<- call;; 
 				-> rrel_1: rrel_fixed: rrel_scp_const:  proc_add_three_elements;;
 				->rrel_2:rrel_fixed:rrel_scp_const: 
-				.proc_of_finding_relations_symmetric_propertes_operator46_params (*
+				..proc_of_finding_relations_symmetric_propertes_operator46_params (*
 					-> rrel_1: rrel_fixed: rrel_scp_var: _result;;
 					-> rrel_2: rrel_fixed: rrel_scp_var: _A;;
 					-> rrel_3: rrel_assign: rrel_scp_var: _answer;;
 				*);;
 				-> rrel_3: rrel_assign: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator47;;
+				=>nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator47;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator47 (*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator47 (*
 				<- waitReturn;;
 				-> rrel_1: rrel_fixed: rrel_scp_var: _descr;;
-				=>nrel_goto: .proc_of_finding_relations_symmetric_propertes_operator_return;;
+				=>nrel_goto: ..proc_of_finding_relations_symmetric_propertes_operator_return;;
 			*);;
 
-			-> .proc_of_finding_relations_symmetric_propertes_operator_return 
-				(*
+			-> ..proc_of_finding_relations_symmetric_propertes_operator_return 
+			(*
 				<- return;;
 			*);;
 		*);;

--- a/set_theory_agents/agents_operations_on_relations/agent_sourcing_of_the_ligaments_relations/agent_sourcing_of_the_ligaments_relations.scsi
+++ b/set_theory_agents/agents_operations_on_relations/agent_sourcing_of_the_ligaments_relations/agent_sourcing_of_the_ligaments_relations.scsi
@@ -6,364 +6,364 @@ agent_sourcing_of_the_ligaments_relations
 
 scp_program -> agent_sourcing_of_the_ligaments_relations 
 	(*
-	-> rrel_params: .agent_sourcing_of_the_ligaments_relations_params 
+	-> rrel_params: ..agent_sourcing_of_the_ligaments_relations_params 
 		(*
 		-> rrel_1: rrel_in: _event;;
 		-> rrel_2: rrel_in: _input_arc;;
 		*);;
 
-	-> rrel_operators: .agent_sourcing_of_the_ligaments_relations_operator_set 
+	-> rrel_operators: ..agent_sourcing_of_the_ligaments_relations_operator_set 
 		(*
-		-> rrel_init: .agent_sourcing_of_the_ligaments_relations_operator1 
+		-> rrel_init: ..agent_sourcing_of_the_ligaments_relations_operator1 
 			(*
-			<- searchElStr3;;
-			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
-			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
-			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
+				<- searchElStr3;;
+				-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
+				-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
+				-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
 
-			=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator2;;
+				=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator2;;
 			*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator2 
+		-> ..agent_sourcing_of_the_ligaments_relations_operator2 
 			(*
-			<- searchElStr3;;
-			-> rrel_1: rrel_fixed: rrel_scp_const: question_sourcing_of_the_ligaments_relations;;
-			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_const: question_sourcing_of_the_ligaments_relations;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
 
-			=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3A;;
-			=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator_return;;
+				=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3A;;
+				=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator_return;;
 			*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3A 
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3A 
 			(*
-			<- searchElStr3;;
-			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
-			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
-			-> rrel_3: rrel_assign: rrel_scp_var: _param;;
+				<- searchElStr3;;
+				-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+				-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+				-> rrel_3: rrel_assign: rrel_scp_var: _param;;
 
-			=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3B;;
-			=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator_return;;
+				=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3B;;
+				=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator_return;;
 			*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3B 
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3B 
 			(*
-		 	<- genEl;;
-		 	-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
+		 		<- genEl;;
+		 		-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
 
-		 	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3C;;
+		 		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3C;;
 		 	*);;
 
 		
-		-> .agent_sourcing_of_the_ligaments_relations_operator3C
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3C
 			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_scp_const: quasybinary_relation;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+				<- searchElStr3;;
+		 		-> rrel_1: rrel_scp_const: quasybinary_relation;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-           	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3C1;;
-           	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4A;;
+           		=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3C1;;
+           		=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4A;;
            	*);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3C1
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3C1
 			(*
-			<- genEl;;
-            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_node;;
+				<- genEl;;
+            	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_node;;
 
-           	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3D;;
+           		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3D;;
            	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3D
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3D
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-            		-> rrel_set_1: rrel_fixed: rrel_scp_var: _set_node;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+            	-> rrel_set_1: rrel_fixed: rrel_scp_var: _set_node;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-           	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3E1;;
-           	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4A;;
+           		=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3E1;;
+           		=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4A;;
           	*);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3E1
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3E1
 			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node3;;
+				<- searchElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _set_node;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: _node3;;
 
-           	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3E2;;
-	       	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator3E4;;
+           		=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3E2;;
+	       		=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator3E4;;
    			*);;
 
-   		-> .agent_sourcing_of_the_ligaments_relations_operator3E2
+   		-> ..agent_sourcing_of_the_ligaments_relations_operator3E2
 			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
+            	<- eraseEl;;
+            	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc;;
             
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3;;
         	*);;
 
-   		-> .agent_sourcing_of_the_ligaments_relations_operator3E3
+   		-> ..agent_sourcing_of_the_ligaments_relations_operator3E3
 			(*
-			<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _node3;;
+				<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _node3;;
 
-           	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3A;;
+           		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3A;;
            	*);;    
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3E3A
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3E3A
 			(*
-			<- genEl;;
-            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_node2;;
+				<- genEl;;
+            	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_node2;;
 
-           	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3B;;
+           		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3B;;
            	*);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3E3B
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3E3B
 			(*
-			<- searchSetStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _node3;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _node4;;
+				<- searchSetStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _node3;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: _node4;;
 
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _set_node2;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_3: rrel_fixed: rrel_scp_var: _set_node2;;
 
-		           	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3C;;
-          			*);;
+		        => nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3C;;
+          	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3E3C
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3E3C
 			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _set_node2;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: _el_node;;
+				<- searchElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _set_node2;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: _el_node;;
 
-          	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3E3D;;
-          	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator3E3G;;
+          		=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3E3D;;
+          		=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator3E3G;;
    			*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3E3D
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3E3D
 			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc1;;
+            	<- eraseEl;;
+            	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _arc1;;
             
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3E;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3E;;
         	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3E3E
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3E3E
 			(*
-			<- searchElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _el_node;;
+				<- searchElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _el_node;;
 
-           	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator3E3C;;
-           	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator3E3F;;
+           		=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator3E3C;;
+           		=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator3E3F;;
            	*);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3E3F
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3E3F
 			(*
-			<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-			-> rrel_3: rrel_fixed: rrel_scp_var: _el_node;;
+				<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+				-> rrel_3: rrel_fixed: rrel_scp_var: _el_node;;
 
-           	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E3C;;
+           		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E3C;;
            	*);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator3E3G
+        -> ..agent_sourcing_of_the_ligaments_relations_operator3E3G
 			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node2;;
+            	<- eraseEl;;
+            	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node2;;
             
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator3E1;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator3E1;;
         	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator3E4
+		-> ..agent_sourcing_of_the_ligaments_relations_operator3E4
 			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node;;
+            	<- eraseEl;;
+            	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_node;;
             
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator5B;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator5B;;
         	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4A
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4A
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_common: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4C;;
-                 	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4B;;
-                 	*);;
-
-		-> .agent_sourcing_of_the_ligaments_relations_operator4B
-			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_edge: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
-
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
-
-                 	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4C;;
-                 	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator5B;;
-                 	*);;
-
-		-> .agent_sourcing_of_the_ligaments_relations_operator4C
-			(*
-			<- searchSetStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
-
-            -> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_ligalement;;
-
-            => nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4D;;
-            => nrel_else: .agent_sourcing_of_the_ligaments_relations_operator5B;;
+                => nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4C;;
+                => nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4B;;
             *);;
 
-        -> .agent_sourcing_of_the_ligaments_relations_operator4D
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4B
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_scp_const: rrel_1;;
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_edge: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node2;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_fixed: rrel_scp_var: _param;;
 
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4E;;
-                 	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4F;;
-                 	*);;
+                => nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4C;;
+                => nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator5B;;
+            *);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4E 
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4C
 			(*
-		 	<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-			-> rrel_3: rrel_scp_const: rrel_1;;
+				<- searchSetStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _param;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_assign: rrel_scp_var: rrel_node: _node1;;
 
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator4F;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+
+            	-> rrel_set_3: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _set_ligalement;;
+
+            	=> nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4D;;
+            	=> nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator5B;;
+            *);;
+
+        -> ..agent_sourcing_of_the_ligaments_relations_operator4D
+			(*
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_scp_const: rrel_1;;
+
+                -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+
+                => nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4E;;
+                => nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4F;;
+            *);;
+
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4E 
+			(*
+		 		<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_scp_const: rrel_1;;
+
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator4F;;
 		 	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4F
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4F
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_scp_const: rrel_2;;
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_scp_const: rrel_2;;
 
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4G;;
-                 	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4H;;
-                 	*);;
+                => nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4G;;
+                => nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4H;;
+            *);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4G
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4G
 			(*
-		 	<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-			-> rrel_3: rrel_scp_const: rrel_2;;
+		 		<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_scp_const: rrel_2;;
 
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator4H;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator4H;;
 		 	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4H
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4H
 			(*
-			<- searchSetStr5;;
-		 	-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
-            -> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
-			-> rrel_5: rrel_scp_const: rrel_3;;
+				<- searchSetStr5;;
+		 		-> rrel_1: rrel_assign: rrel_scp_var: rrel_node: _node1;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_fixed: rrel_scp_var: _set_ligalement;;
+            	-> rrel_4: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc2;;
+				-> rrel_5: rrel_scp_const: rrel_3;;
 
-                 	-> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
-                 	-> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
-		 			-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_1: rrel_fixed: rrel_scp_var: _answer;;
+                -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_set_4: rrel_fixed: rrel_scp_var: _answer;;
 
-                 	=> nrel_then: .agent_sourcing_of_the_ligaments_relations_operator4E;;
-                 	=> nrel_else: .agent_sourcing_of_the_ligaments_relations_operator4F;;
-                 	*);;
+                => nrel_then: ..agent_sourcing_of_the_ligaments_relations_operator4E;;
+                => nrel_else: ..agent_sourcing_of_the_ligaments_relations_operator4F;;
+            *);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator4E
+		-> ..agent_sourcing_of_the_ligaments_relations_operator4E
 			(*
-		 	<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
-			-> rrel_3: rrel_scp_const: rrel_3;;
+		 		<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc1;;
+				-> rrel_3: rrel_scp_const: rrel_3;;
 
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator5A;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator5A;;
 		 	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator5A
+		-> ..agent_sourcing_of_the_ligaments_relations_operator5A
 			(*
-            <- eraseEl;;
-            -> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_ligalement;;
+            	<- eraseEl;;
+            	-> rrel_1: rrel_fixed: rrel_scp_var: rrel_erase: _set_ligalement;;
             
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator5B;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator5B;;
         	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator5B
+		-> ..agent_sourcing_of_the_ligaments_relations_operator5B
 			(*
-		 	<- genElStr3;;
-		 	-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
-		 	-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
-		 	-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
+		 		<- genElStr3;;
+		 		-> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+		 		-> rrel_2: rrel_assign: rrel_scp_var: rrel_pos_const_perm: _arc1;;
+		 		-> rrel_3: rrel_fixed: rrel_scp_var: _param;;
 
-            => nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator_gen_answer;;
+            	=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator_gen_answer;;
 		 	*);;
 
-		-> .agent_sourcing_of_the_ligaments_relations_operator_gen_answer 
+		-> ..agent_sourcing_of_the_ligaments_relations_operator_gen_answer 
 			(*
-		  	<- genElStr5;;
-		  	-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
-		  	-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc;;
-		  	-> rrel_3: rrel_fixed: rrel_scp_var: _answer;;
-		  	-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
-		  	-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
+		  		<- genElStr5;;
+		  		-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+		  		-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_scp_var: _arc;;
+		  		-> rrel_3: rrel_fixed: rrel_scp_var: _answer;;
+		  		-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
+		  		-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
 
-		  	=> nrel_goto: .agent_sourcing_of_the_ligaments_relations_operator_return;;
+		  		=> nrel_goto: ..agent_sourcing_of_the_ligaments_relations_operator_return;;
 			*);;    
 
-		 -> .agent_sourcing_of_the_ligaments_relations_operator_return 
+		 -> ..agent_sourcing_of_the_ligaments_relations_operator_return 
 			(*
-		  	<- return;;
+		  		<- return;;
 			*);;
 		*);;
 	*);;


### PR DESCRIPTION
**Fix proc_of_finding_converse_relation:**
После проверки алгоритма и тестировании агента ошибок найдено не было. Точка в начале операторов изменена на две точки.
  
**Fix proc_of_finding_relations_propertes:**
Добавлена проверка на принадлежность входного отношения к классу
антитранзитывных отношений. Теперь проверка на транзитивность, рефлексивность, симметричность выполняется, только если входное отношение является бинарным. Точка в начале операторов изменена на две точки.
  
**Fix proc_of_finding_relations_symmetric_propertes:**
Исправлена проверка отношения на асимметричность. Добавлена проверка на принадлежность входного отношения к классу бинарное отношение. Точка в начале операторов изменена на две точки.
  
**Fix agent_sourcing_of_the_ligaments_relations:**
После проверки алгоритма и тестировании агента ошибок найдено не
было. Точка в начале операторов изменена на две точки.